### PR TITLE
Remove gio from gbuild’s dependencies

### DIFF
--- a/gbuild/Cargo.toml
+++ b/gbuild/Cargo.toml
@@ -19,5 +19,4 @@ categories = ["development-tools::build-utils"]
 [dependencies]
 cc = "1.0"
 derive_builder = "0.10"
-gio = "0.9"
 quick-xml = "0.22"


### PR DESCRIPTION
This crate doesn’t use the `gio` crate from Rust, instead it uses pkg-config to
obtain its `CFLAGS`, so it makes sense to remove this dependency to lighten up
your maintenance burden (that dependency was out of date already).

gbuild-test continues to use this dependency.